### PR TITLE
feature/mail attachments

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -24,7 +24,7 @@ app.use(morgan(format, { stream: new LoggerStream('request', 'debug') }));
 
 app.use(bodyParser.urlencoded({ extended: true }));
 app.use(bodyParser.json({
-	limit: (10 * 1024 * 1024) // 10MB
+	limit: (10 * 1024 * 1024), // 10MB
 }));
 
 // view engine setup
@@ -49,7 +49,8 @@ app.use((err: HttpException, req: Request, res: Response, next: NextFunction) =>
 	res.locals.error = req.app.get('NODE_ENV') !== 'production' ? err : {};
 	const status = err.status || 500;
 
-	console.error(err)
+	// tslint:disable-next-line no-console
+	console.error(err);
 
 	// render the error page
 	res.status(status);

--- a/src/app.ts
+++ b/src/app.ts
@@ -23,7 +23,9 @@ const format = mjson(':status :method :url :res[content-length] bytes :response-
 app.use(morgan(format, { stream: new LoggerStream('request', 'debug') }));
 
 app.use(bodyParser.urlencoded({ extended: true }));
-app.use(bodyParser.json());
+app.use(bodyParser.json({
+	limit: (10 * 1024 * 1024) // 10MB
+}));
 
 // view engine setup
 app.set('views', path.join(__dirname, 'views'));
@@ -46,6 +48,8 @@ app.use((err: HttpException, req: Request, res: Response, next: NextFunction) =>
 	res.locals.message = err.message || 'unknown error';
 	res.locals.error = req.app.get('NODE_ENV') !== 'production' ? err : {};
 	const status = err.status || 500;
+
+	console.error(err)
 
 	// render the error page
 	res.status(status);

--- a/src/interfaces/Mail.ts
+++ b/src/interfaces/Mail.ts
@@ -4,4 +4,5 @@ export default interface Mail {
 	subject: string;
 	text: string;
 	html: string;
+	attachments?: {content: Buffer|string, filename: string}[];
 }

--- a/src/interfaces/Mail.ts
+++ b/src/interfaces/Mail.ts
@@ -4,5 +4,5 @@ export default interface Mail {
 	subject: string;
 	text: string;
 	html: string;
-	attachments?: {content: Buffer|string, filename: string}[];
+	attachments?: Array<{content: Buffer|string, filename: string}>;
 }

--- a/src/routes/mail.ts
+++ b/src/routes/mail.ts
@@ -13,6 +13,7 @@ router.post('/', (req, res) => {
 		subject: req.body.subject,
 		text: req.body.text,
 		html: req.body.html,
+		attachments: req.body.attachments,
 	};
 
 	if (req.body.from) {

--- a/src/services/MailService.ts
+++ b/src/services/MailService.ts
@@ -26,14 +26,14 @@ export default class MailService extends BaseService {
 
 	protected _send(transporter: nodeMailer.Transporter, mail: Mail): Promise<SentMessageInfo> {
 
-    if(mail.attachments){
-      const decodeFiles = (files: {content: any, filename: string}[]) => files.map(({ content, filename }) => ({
-        filename,
-        content: Buffer.from(content, 'base64'),
-      }));
-      const decodedAttachments = decodeFiles(mail.attachments);
-      mail.attachments = decodedAttachments
-    }
+		if (mail.attachments) {
+			const decodeFiles = (files: Array<{content: any, filename: string}>) => files.map(({ content, filename }) => ({
+				filename,
+				content: Buffer.from(content, 'base64'),
+			}));
+			const decodedAttachments = decodeFiles(mail.attachments);
+			mail.attachments = decodedAttachments;
+		}
 
 		return transporter.sendMail(mail);
 	}

--- a/src/services/MailService.ts
+++ b/src/services/MailService.ts
@@ -25,6 +25,16 @@ export default class MailService extends BaseService {
 	}
 
 	protected _send(transporter: nodeMailer.Transporter, mail: Mail): Promise<SentMessageInfo> {
+
+    if(mail.attachments){
+      const decodeFiles = (files: {content: any, filename: string}[]) => files.map(({ content, filename }) => ({
+        filename,
+        content: Buffer.from(content, 'base64'),
+      }));
+      const decodedAttachments = decodeFiles(mail.attachments);
+      mail.attachments = decodedAttachments
+    }
+
 		return transporter.sendMail(mail);
 	}
 

--- a/swagger.json
+++ b/swagger.json
@@ -204,6 +204,10 @@
         "html": {
           "type": "string",
           "description": "HTML content of mail"
+        },
+        "attachments": {
+          "type": "array",
+          "description": "Attachments of the mail"
         }
       },
       "example": {
@@ -211,7 +215,13 @@
         "to": "sample@sample.org",
         "subject": "New foo bar available",
         "text": "Order our new foo bar for only $42.",
-        "html": "<html>Order our new foo bar for only $42.</html>"
+        "html": "<html>Order our new foo bar for only $42.</html>",
+        "attachments": [
+          {
+            "filename": "base64EncodedContent.gif",
+            "content": "R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+          }
+        ]
       }
     },
     "Push": {


### PR DESCRIPTION
the mails endpoint now allows attachments. The content of these attachments must be base64 encoded.

```ts
export default interface Mail {
	from?: string;
	to: string;
	subject: string;
	text: string;
	html: string;
	attachments?: Array<{content: Buffer|string, filename: string}>;
}
```