### PR TITLE
Revert "SC-4223 Notification Service soll vei Verlust der Verbindung zu Redis…"

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -106,13 +106,6 @@ class Utils {
 		if (!options.redis) { options.redis = {}; }
 		options.redis.host = process.env.REDIS_HOST || '127.0.0.1';
 		options.redis.port = parseInt(process.env.REDIS_PORT || '6379', undefined);
-		options.redis.retry_strategy = (opts) => {
-			if (opts.attempt >= parseInt(process.env.REDIS_RETRY_ATTEMPTS || '3', 10)) {
-				logger.error('Unable to connect to the Redis server - Notification Service is going to exit!');
-				process.exit(1);
-			}
-			return (opts.attempt + 1) * 1000;
-		};
 		logger.debug('redis config: ', options);
 		return options;
 	}


### PR DESCRIPTION
Reverts schul-cloud/node-notification-service#179 due to this is breaking the build.